### PR TITLE
Remove secret store snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,6 @@ Below is an updated `home.nix` that enables KDE **Wayland** by default, removes 
   programs.konsole.package = config.lib.nixGL.wrap pkgs.konsole;
   programs.firefox.package = config.lib.nixGL.wrap pkgs.firefox;
   nixGL.defaultWrapper = "nvidia";   # choose "nvidia" or "mesa"
-    "store --file ${config.age.secrets.githubToken.path}";
 
   # ---- Theming ---------------------------------------------------------
   stylix = {

--- a/main/home.nix
+++ b/main/home.nix
@@ -31,7 +31,6 @@
   programs.konsole.package = config.lib.nixGL.wrap pkgs.konsole;
   programs.firefox.package = config.lib.nixGL.wrap pkgs.firefox;
   nixGL.defaultWrapper = "nvidia";   # choose "nvidia" or "mesa"
-    "store --file ${config.age.secrets.githubToken.path}";
 
   # ---- Theming ---------------------------------------------------------
   stylix = {


### PR DESCRIPTION
## Summary
- remove leftover `store --file` github token line from `home.nix`
- keep README snippet in sync

## Testing
- `nix flake check` *(fails: `nix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c2cf1b8488330a512e41a335f8295