### PR TITLE
Fix locale comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ locale-gen
 # Set system locale
 cat << EOF > /etc/locale.conf
 LANG=en_US.UTF-8
-LC_TIME=nb_NO.UTF-8 # Optional if you want to set the date & time to a specific LANG default
+LC_TIME=nb_NO.UTF-8 # Optional if you want a specific LANG default
 EOF
 
 # Set console keymap. This even U.S keyboards has to set!


### PR DESCRIPTION
## Summary
- fix LC_TIME comment wording

## Testing
- `grep -n LC_TIME -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_688c2f5655348330972bc4e8f6456f9f