### PR TITLE
Add FusionSync helper system

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,3 +502,32 @@ Other recommended caches include *FlakeHub* and *Determinate Systems*.
 
 ---
 
+
+## 7\u00a0FusionSync
+
+**FusionSync** keeps pacman upgrades coherent with the Nix desktop.
+It consists of two parts:
+
+1. A pacman hook writes updated package names to `/var/lib/fusionsync/pacman.log`.
+2. `fusion-sync` watches this log, regenerates `nixGL`/`nix-ld` wrappers and runs `home-manager switch` whenever core libraries change.
+
+Install it with:
+
+```bash
+sudo install -Dm755 fusion-sync/fusion-sync.sh /usr/local/bin/fusion-sync
+sudo install -Dm644 fusion-sync/fusion-sync.hook /etc/pacman.d/hooks/fusion-sync.hook
+```
+
+Enable the daemon (per-user):
+
+```bash
+systemctl --user enable --now fusion-sync.service
+```
+
+Daily updates are as easy as:
+
+```bash
+fusion-sync upgrade
+```
+
+This synchronizes pacman and Nix, reducing breakage after system upgrades.

--- a/fusion-sync/fusion-sync.hook
+++ b/fusion-sync/fusion-sync.hook
@@ -1,0 +1,9 @@
+[Trigger]
+Operation = Upgrade
+Type = Package
+Target = *
+
+[Action]
+Description = Record updated package for FusionSync
+When = PostTransaction
+Exec = /usr/local/bin/fusion-sync pacman-hook %n

--- a/fusion-sync/fusion-sync.service
+++ b/fusion-sync/fusion-sync.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=FusionSync daemon
+
+[Service]
+ExecStart=/usr/local/bin/fusion-sync daemon
+Restart=always
+
+[Install]
+WantedBy=default.target

--- a/fusion-sync/fusion-sync.sh
+++ b/fusion-sync/fusion-sync.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# FusionSync: Keep pacman and Nix environments synchronized
+
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") COMMAND
+
+Commands:
+  upgrade          Run pacman upgrade and rebuild Nix environment
+  rebuild          Regenerate wrappers and run home-manager switch
+  daemon           Start the FusionSync watcher daemon
+  pacman-hook      Record updated packages from pacman hook
+USAGE
+}
+
+log_dir="/var/lib/fusionsync"
+log_file="$log_dir/pacman.log"
+
+ensure_state() {
+  sudo mkdir -p "$log_dir"
+  sudo touch "$log_file"
+}
+
+record_update() {
+  ensure_state
+  local pkg=$1
+  echo "$(date -u +%FT%T) $pkg" | sudo tee -a "$log_file" >/dev/null
+}
+
+regenerate_wrappers() {
+  echo "[FusionSync] Regenerating nixGL and nix-ld wrappers" >&2
+  # nixGL wrapper regeneration
+  if command -v nixGL >/dev/null; then
+    nixGL --auto --print-shell-hooks > "$log_dir/nixgl.sh"
+  fi
+  # nix-ld wrapper regeneration
+  if command -v nix-ld >/dev/null; then
+    sudo nix-ld --print-root | sudo tee "$log_dir/nix-ld-root" >/dev/null
+  fi
+}
+
+run_home_manager() {
+  if command -v home-manager >/dev/null; then
+    home-manager switch
+  fi
+}
+
+self_test() {
+  echo "[FusionSync] Running GUI test" >&2
+  if command -v systemd-run >/dev/null; then
+    systemd-run --quiet --user --scope bash -c "${HOME}/.nix-profile/bin/xdg-open https://example.com" && return 0
+  fi
+  return 1
+}
+
+rebuild() {
+  regenerate_wrappers
+  if self_test; then
+    run_home_manager
+  else
+    echo "[FusionSync] Self-test failed; aborting rebuild" >&2
+    return 1
+  fi
+}
+
+upgrade() {
+  sudo pacman -Syu --noconfirm
+  rebuild
+}
+
+daemon() {
+  ensure_state
+  echo "[FusionSync] Watching $log_file for changes" >&2
+  tail -Fn0 "$log_file" | while read -r line; do
+    pkg=$(echo "$line" | awk '{print $2}')
+    echo "[FusionSync] Detected update for $pkg" >&2
+    rebuild
+  done
+}
+
+case "${1:-}" in
+  upgrade) upgrade ;;
+  rebuild) rebuild ;;
+  daemon) daemon ;;
+  pacman-hook) shift; record_update "$@" ;;
+  *) usage ;;
+esac


### PR DESCRIPTION
## Summary
- add FusionSync script, pacman hook and service
- document FusionSync usage in README

## Testing
- `shellcheck fusion-sync/fusion-sync.sh`
- `nix --extra-experimental-features 'nix-command flakes' flake show ./main`
- `nix --extra-experimental-features 'nix-command flakes' flake check ./main`

------
https://chatgpt.com/codex/tasks/task_e_688c34c2fe248330bf922674920046f8